### PR TITLE
fix: make symlinks for firmware after download

### DIFF
--- a/firmware/awinic/aw87xxx_acf_air1s.bin
+++ b/firmware/awinic/aw87xxx_acf_air1s.bin
@@ -1,1 +1,0 @@
-aw87xxx_acf_minipro.bin

--- a/firmware/awinic/aw87xxx_acf_airplus.bin
+++ b/firmware/awinic/aw87xxx_acf_airplus.bin
@@ -1,1 +1,0 @@
-aw87xxx_acf_minipro.bin

--- a/firmware/bazzite-speaker.sh
+++ b/firmware/bazzite-speaker.sh
@@ -11,9 +11,12 @@ INSTALL_DIR="/usr/local/firmware"
 
 # Download firmware
 mkdir -p $INSTALL_DIR
-wget -O $INSTALL_DIR/aw87xxx_acf_air1s.bin    $BASE_DIR/awinic/aw87xxx_acf_air1s.bin
-wget -O $INSTALL_DIR/aw87xxx_acf_airplus.bin  $BASE_DIR/awinic/aw87xxx_acf_airplus.bin
 wget -O $INSTALL_DIR/aw87xxx_acf_flip.bin     $BASE_DIR/awinic/aw87xxx_acf_flip.bin
 wget -O $INSTALL_DIR/aw87xxx_acf_kun.bin      $BASE_DIR/awinic/aw87xxx_acf_kun.bin
 wget -O $INSTALL_DIR/aw87xxx_acf_minipro.bin  $BASE_DIR/awinic/aw87xxx_acf_minipro.bin
 wget -O $INSTALL_DIR/aw87xxx_acf_orangepi.bin $BASE_DIR/awinic/aw87xxx_acf_orangepi.bin
+
+# Symlink firmware for air1s and airplus
+cd $INSTALL_DIR
+ln -s aw87xxx_acf_minipro.bin aw87xxx_acf_air1s.bin
+ln -s aw87xxx_acf_minipro.bin aw87xxx_acf_airplus.bin


### PR DESCRIPTION
wget and curl downloads the symlinks as text files instead of symlinks.
This changes the script to make the symlink after download instead.